### PR TITLE
Removing -f param as it is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ the images for both `mono` and `coreclr`, it will take care of using the right t
 images produced. To be able to push to the repository you will need write access to the `b.gcr.io/aspnet-docker`
 repository.
 
+The build of the image has been tested with Docker 1.10.
+
 ## Support
 To get help on using the aspnet runtime, please log an issue with this
 project. While we will eventually be able to offer support on Stack Overflow or

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -25,7 +25,7 @@ build_docker_image () {
     # Tag the runtime version as the latest version.
     local latest_tag="$(get_docker_tag latest)"
     echo Tagging ${runtime_tag} as ${latest_tag}
-    docker tag -f ${runtime_tag} ${latest_tag}
+    docker tag ${runtime_tag} ${latest_tag}
 }
 
 # Pushes the container to the repository indicated by the tag. This function


### PR DESCRIPTION
Since Docker 1.10 the -f param is marked as deprecated and no longer needed to update the tag for an existing image. This change removes this and makes it to the required version of Docker is 1.10 to build the image.
