### PR TITLE
Storing the runtime in GCS.

### DIFF
--- a/dotnet_runtime/Dockerfile
+++ b/dotnet_runtime/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 
 # Install the package.
 RUN mkdir -p /usr/share/dotnet && \
-    curl -sL https://storage.googleapis.com/aspnet/dotnet-debian-x64.1.0.1.tar.gz | tar -xzv -C /usr/share/dotnet/ && \
+    curl -sL https://storage.googleapis.com/aspnet-docker-deps/dotnet-debian-x64.1.0.1.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Expose the port for the app.

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -35,12 +35,12 @@ push_docker_image () {
     # Pushing the versioned tag.
     local versioned_tag="$(get_docker_tag ${RUNTIME_VERSION})"
     echo Pushing ${versioned_tag}
-    gcloud docker push ${versioned_tag}
+    gcloud docker -- push ${versioned_tag}
 
     # Pushing the latest tag as well.
     local latest_tag="$(get_docker_tag latest)"
     echo Pushing ${latest_tag}
-    gcloud docker push ${latest_tag}
+    gcloud docker -- push ${latest_tag}
 }
 
 # Run the image with the given name.


### PR DESCRIPTION
Store the runtime bits in GCS to avoid external dependencies.
