### PR TITLE
prevent container build from using cached images

### DIFF
--- a/dotnet_runtime/cloudbuild.yaml.in
+++ b/dotnet_runtime/cloudbuild.yaml.in
@@ -1,6 +1,6 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: [ 'build', '-t', '${IMAGE}', '--no-cache', '.' ]
+  args: [ 'build', '-t', '${IMAGE}', '--no-cache', '--pull', '.' ]
 - name: gcr.io/gcp-runtimes/structure_test
   args: ['-i', '${IMAGE}', '--config', '/workspace/aspnet.yaml', '-v']
 images:


### PR DESCRIPTION
this will ensure security updates are picked up in the cloud build.