### PR TITLE
Updating to the version 1.0.3 of the runtime.

### DIFF
--- a/dotnet_runtime/Dockerfile
+++ b/dotnet_runtime/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 
 # Install the package.
 RUN mkdir -p /usr/share/dotnet && \
-    curl -sL https://storage.googleapis.com/aspnet-docker-deps/dotnet-debian-x64.1.0.1.tar.gz | tar -xz -C /usr/share/dotnet/ && \
+    curl -sL https://storage.googleapis.com/aspnet-docker-deps/dotnet-debian-x64.1.0.3.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Expose the port for the app.

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 
 readonly image_name="aspnet"
-readonly tag="1.0.1"
+readonly tag="1.0.3"
 
 export IMAGE_DIR="$1"
 


### PR DESCRIPTION
Updates the runtime to version 1.0.3 of the LTS branch. Able to run apps created with the .NET Core 1.0.x tooling.