### PR TITLE
Refer to the actual image to use.

### DIFF
--- a/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
+++ b/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
@@ -20,7 +20,7 @@ DEPS_EXTENSION = '.deps.json'
 DOCKERFILE_NAME = 'Dockerfile'
 DOCKERFILE_CONTENTS = textwrap.dedent(
     """\
-    FROM gcr.io/google-appengine/aspnetcore:1.0.3
+    FROM gcr.io/google-appengine/aspnetcore@sha256:a5cb3f4a9be727ed449771d8018f29696a53bf9116a94b81c3d7719cb97b99af
     ADD ./ /app
     ENV ASPNETCORE_URLS=http://*:${{PORT}}
     WORKDIR /app


### PR DESCRIPTION
This PR changes the generated Dockerfile from the builder to refer back to the base image directly by sha256 digest instead of by tag. This will ensure that the build is always repeatable. If and when the runtime image is udpated this generated Dockerfile will have to be updated.

This is a temporary solution, a better solution is coming down the line where there will be a parameter passed into the builder with the base image to use. 