### PR TITLE
Runtime image param

### DIFF
--- a/aspnetcore-1.0.yaml
+++ b/aspnetcore-1.0.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/aspnetcorebuild-1.0:latest'
-  args: [ '-runtime-image', 'gcr.io/google-appengine/aspnetcore:1.0' ]
+  args: [ '--runtime-image', 'gcr.io/google-appengine/aspnetcore:1.0' ]
 - name: gcr.io/cloud-builders/docker:latest
   args: [ 'build', '-t', '$_OUTPUT_IMAGE', '--no-cache', '--pull', '.' ]
 images:

--- a/aspnetcore-1.0.yaml
+++ b/aspnetcore-1.0.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/aspnetcorebuild-1.0:latest'
-  args: [ '-r', 'gcr.io/google-appengine/aspnetcore:1.0' ]
+  args: [ '-runtime-image', 'gcr.io/google-appengine/aspnetcore:1.0' ]
 - name: gcr.io/cloud-builders/docker:latest
   args: [ 'build', '-t', '$_OUTPUT_IMAGE', '--no-cache', '--pull', '.' ]
 images:

--- a/aspnetcore-1.0.yaml
+++ b/aspnetcore-1.0.yaml
@@ -1,5 +1,6 @@
 steps:
 - name: 'gcr.io/gcp-runtimes/aspnetcorebuild-1.0:latest'
+  args: [ '-r', 'gcr.io/google-appengine/aspnetcore:1.0' ]
 - name: gcr.io/cloud-builders/docker:latest
   args: [ 'build', '-t', '$_OUTPUT_IMAGE', '--no-cache', '--pull', '.' ]
 images:

--- a/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
+++ b/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
@@ -23,10 +23,19 @@ It is assumed that the current directory is the published directory.
 
 """
 
+import argparse
 import glob
 import os
 import sys
 import textwrap
+
+
+# Arguments for the builder.
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument('-r', '--runtime-image',
+                    dest='runtime_image',
+                    help='The runtime image to use for the Dockerfile.',
+                    required=True)
 
 
 ASSEMBLY_NAME_TEMPLATE = '{0}.dll'
@@ -35,11 +44,11 @@ DEPS_EXTENSION = '.deps.json'
 DOCKERFILE_NAME = 'Dockerfile'
 DOCKERFILE_CONTENTS = textwrap.dedent(
     """\
-    FROM gcr.io/google-appengine/aspnetcore@sha256:a5cb3f4a9be727ed449771d8018f29696a53bf9116a94b81c3d7719cb97b99af
+    FROM {0}
     ADD ./ /app
     ENV ASPNETCORE_URLS=http://*:${{PORT}}
     WORKDIR /app
-    ENTRYPOINT [ "dotnet", "{0}.dll" ]
+    ENTRYPOINT [ "dotnet", "{1}.dll" ]
     """)
 
 
@@ -72,7 +81,7 @@ def get_deps_path():
     return files[0]
 
 
-def main():
+def main(params):
     """Ensures that a Dockerfile exists in the current directory.
 
     Assumest that the current directory is set to the root of the
@@ -97,11 +106,11 @@ def main():
 
     # Need to create the Dockerfile, we need to get the name of the
     # project to use.
-    contents = DOCKERFILE_CONTENTS.format(project_name)
+    contents = DOCKERFILE_CONTENTS.format(params.runtime_image, project_name)
     with open(DOCKERFILE_NAME, 'wt') as out:
         out.write(contents)
 
 
 # Start the script.
 if __name__ == '__main__':
-    main()
+    main(PARSER.parse_args())

--- a/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
+++ b/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
@@ -90,9 +90,15 @@ def main(params):
     main assembly for the project.
 
     """
+
+    # The app cannot specify it's own Dockerfile when building with
+    # the aspnetcore image, the builder is the one that has to build
+    # it. To avoid any confusion the builder will fail with this
+    # error.
     if os.path.isfile(DOCKERFILE_NAME):
-        print 'Dockerfile already exists.'
-        return
+        print ('A Dockerfile already exists in the workspace, this Dockerfile ' +
+               'cannot be used with the aspnetcore runtime.')
+        sys.exit(1)
 
     deps_path = get_deps_path()
     if deps_path is None:

--- a/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
+++ b/build_pipelines/aspnetcorebuild-1.0/prepare_project.py
@@ -30,25 +30,17 @@ import sys
 import textwrap
 
 
-# Arguments for the builder.
-PARSER = argparse.ArgumentParser()
-PARSER.add_argument('-r', '--runtime-image',
-                    dest='runtime_image',
-                    help='The runtime image to use for the Dockerfile.',
-                    required=True)
-
-
 ASSEMBLY_NAME_TEMPLATE = '{0}.dll'
 DEPS_PATTERN = '*.deps.json'
 DEPS_EXTENSION = '.deps.json'
 DOCKERFILE_NAME = 'Dockerfile'
 DOCKERFILE_CONTENTS = textwrap.dedent(
     """\
-    FROM {0}
+    FROM {runtime_image}
     ADD ./ /app
     ENV ASPNETCORE_URLS=http://*:${{PORT}}
     WORKDIR /app
-    ENTRYPOINT [ "dotnet", "{1}.dll" ]
+    ENTRYPOINT [ "dotnet", "{dll_name}.dll" ]
     """)
 
 
@@ -112,11 +104,16 @@ def main(params):
 
     # Need to create the Dockerfile, we need to get the name of the
     # project to use.
-    contents = DOCKERFILE_CONTENTS.format(params.runtime_image, project_name)
+    contents = DOCKERFILE_CONTENTS.format(runtime_image=params.runtime_image, dll_name=project_name)
     with open(DOCKERFILE_NAME, 'wt') as out:
         out.write(contents)
 
 
 # Start the script.
 if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument('-r', '--runtime-image',
+                        dest='runtime_image',
+                        help='The runtime image to use for the Dockerfile.',
+                        required=True)
     main(PARSER.parse_args())


### PR DESCRIPTION
This PR updates the runtime builder script to get the base image from the --runtime-image (or -r) parameter. The runtime image will be used as the base image, in the `FROM` statement, in the generated `Dockerfile`.

This PR also adds logic to fail if a `Dockerfile` is found in the workspace. Having a pre-existing `Dockerfile` causes ambiguity about which one is going to be used. The script will now fail, with exit code 1, when a pre-existing `Dockerfile` is found.

The runtime builder is also updated to specify the runtime image, which will refer to the 1.0 image since this is the runtime builder for ASP.NET Core 1.0.

Fixed #30 