### PR TITLE
Fixing the absence of the TAG environment variable.

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -48,7 +48,7 @@ cleanup() {
 }
 
 # Process the template.
-if [ -z "${TAG}" ]; then
+if [ -z "${TAG:-}" ]; then
   TAG=$(date +"%Y-%m-%d_%H_%M")
 fi
 


### PR DESCRIPTION
This PR fixes a script break when running on a dev machine, where the `TAG` variable will not be defined.