### PR TITLE
Adding the .NET Core runtime version to the tag

### DIFF
--- a/runtimes/aspnetcore-1.0.3/cloudbuild.yaml.in
+++ b/runtimes/aspnetcore-1.0.3/cloudbuild.yaml.in
@@ -1,7 +1,7 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: [ 'build', '-t', '${REPO}/aspnetcore:${VERSION}', '--no-cache', '--pull', '.' ]
+  args: [ 'build', '-t', '${REPO}/aspnetcore:1.0.3-${VERSION}', '--no-cache', '--pull', '.' ]
 - name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', '${REPO}/aspnetcore:${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
+  args: ['-i', '${REPO}/aspnetcore:1.0.3-${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
 images:
-  ['${REPO}/aspnetcore:${VERSION}']
+  ['${REPO}/aspnetcore:1.0.3-${VERSION}']

--- a/runtimes/aspnetcore-1.0.4/cloudbuild.yaml.in
+++ b/runtimes/aspnetcore-1.0.4/cloudbuild.yaml.in
@@ -1,7 +1,7 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: [ 'build', '-t', '${REPO}/aspnetcore:${VERSION}', '--no-cache', '--pull', '.' ]
+  args: [ 'build', '-t', '${REPO}/aspnetcore:1.0.4-${VERSION}', '--no-cache', '--pull', '.' ]
 - name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', '${REPO}/aspnetcore:${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
+  args: ['-i', '${REPO}/aspnetcore:1.0.4-${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
 images:
-  ['${REPO}/aspnetcore:${VERSION}']
+  ['${REPO}/aspnetcore:1.0.4-${VERSION}']

--- a/runtimes/aspnetcore-1.1.1/cloudbuild.yaml.in
+++ b/runtimes/aspnetcore-1.1.1/cloudbuild.yaml.in
@@ -1,7 +1,7 @@
 steps:
 - name: gcr.io/cloud-builders/docker
-  args: [ 'build', '-t', '${REPO}/aspnetcore:${VERSION}', '--no-cache', '--pull', '.' ]
+  args: [ 'build', '-t', '${REPO}/aspnetcore:1.1.1-${VERSION}', '--no-cache', '--pull', '.' ]
 - name: gcr.io/gcp-runtimes/structure_test
-  args: ['-i', '${REPO}/aspnetcore:${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
+  args: ['-i', '${REPO}/aspnetcore:1.1.1-${VERSION}', '--config', '/workspace/aspnet.yaml', '-v']
 images:
-  ['${REPO}/aspnetcore:${VERSION}']
+  ['${REPO}/aspnetcore:1.1.1-${VERSION}']


### PR DESCRIPTION
This PR adds version of the image to the tag so the version can be easily identified later on when the build of the image happens. Currently because we only use the date it is not easy to identify what runtime is being built.