### PR TITLE
Master add port urls env vars

### DIFF
--- a/builder/src/prepare_project.py
+++ b/builder/src/prepare_project.py
@@ -40,7 +40,6 @@ DOCKERFILE_CONTENTS = textwrap.dedent(
     """\
     FROM {runtime_image}
     ADD ./ /app
-    ENV ASPNETCORE_URLS=http://*:${{PORT}}
     WORKDIR /app
     ENTRYPOINT [ "dotnet", "{dll_name}.dll" ]
     """)

--- a/runtimes/aspnetcore-1.0/versions/1.0.3/Dockerfile
+++ b/runtimes/aspnetcore-1.0/versions/1.0.3/Dockerfile
@@ -37,5 +37,10 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.0.3.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT
+

--- a/runtimes/aspnetcore-1.0/versions/1.0.4/Dockerfile
+++ b/runtimes/aspnetcore-1.0/versions/1.0.4/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.0.4.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-1.0/versions/1.0.5/Dockerfile
+++ b/runtimes/aspnetcore-1.0/versions/1.0.5/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.0.5.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-1.0/versions/1.0.7/Dockerfile
+++ b/runtimes/aspnetcore-1.0/versions/1.0.7/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.0.7.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-1.1/versions/1.1.1/Dockerfile
+++ b/runtimes/aspnetcore-1.1/versions/1.1.1/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.1.1.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-1.1/versions/1.1.2/Dockerfile
+++ b/runtimes/aspnetcore-1.1/versions/1.1.2/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.1.2.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-1.1/versions/1.1.4/Dockerfile
+++ b/runtimes/aspnetcore-1.1/versions/1.1.4/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-debian-x64.1.1.4.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/runtimes/aspnetcore-2.0/versions/2.0.0/Dockerfile
+++ b/runtimes/aspnetcore-2.0/versions/2.0.0/Dockerfile
@@ -37,5 +37,9 @@ RUN mkdir -p /usr/share/dotnet && \
     curl -sL https://storage.googleapis.com/gcp-aspnetcore-packages/dotnet-sdk-2.0.0-linux-x64.tar.gz | tar -xz -C /usr/share/dotnet/ && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+# Define the environment variables
+ENV PORT=8080
+ENV ASPNETCORE_URLS=http://*:${PORT}
+
 # Expose the port for the app.
 EXPOSE $PORT

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -74,7 +74,7 @@ else
 fi
 
 # Deploy and run the tests.
-gcloud beta app deploy ${app_yaml} --quiet --verbosity=info --version=${version_id} --no-promote
+gcloud app deploy ${app_yaml} --quiet --verbosity=info --version=${version_id} --no-promote
 gcloud container builds submit \
     --config=${run_script} \
     --substitutions _VERSION_ID=${version_id} \


### PR DESCRIPTION
Define the `ASPNETCORE_URLS` environment variables in the base image instead of doing that in the app's image. Also define the `PORT` environment variable in the base image, in case it disappears from the upstream base image.

Fixes #74 