### PR TITLE
Update the builds scripts to match changes to Cloud Build

### DIFF
--- a/tools/submit_build.sh
+++ b/tools/submit_build.sh
@@ -40,6 +40,6 @@ fi
 
 # Start the build.
 readonly build_dir=$(dirname $1) 
-gcloud container builds submit "${build_dir}" \
+gcloud builds submit "${build_dir}" \
     --config="$1" \
     --substitutions _DOCKER_NAMESPACE=${repo},_TAG=${TAG}

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -76,7 +76,7 @@ fi
 
 # Deploy and run the tests.
 gcloud app deploy ${app_yaml} --quiet --verbosity=info --version=${version_id} --no-promote
-gcloud container builds submit \
+gcloud builds submit \
     --config=${run_script} \
     --substitutions _VERSION_ID=${version_id} \
     --quiet \


### PR DESCRIPTION
Container Builder was consumed by Cloud Build and now the builds happen via `gcloud build` instead of `gcloud container builds`

The nightly tests are failing as the gcloud container build command fails