### PR TITLE
WIP: Initial implementation for the aspnet updater

### DIFF
--- a/aspnetcore.yaml
+++ b/aspnetcore.yaml
@@ -5,7 +5,9 @@ steps:
     - '1.0.14=gcr.io/google-appengine/aspnetcore:1.0.14'
     - '1.1.11=gcr.io/google-appengine/aspnetcore:1.1.11'
     - '2.0.9=gcr.io/google-appengine/aspnetcore:2.0.9'
-    - '2.1.8=gcr.io/google-appengine/aspnetcore:2.1.8'
+    - '2.111=gcr.io/google-appengine/aspnetcore:2.111'
     - '2.2.2=gcr.io/google-appengine/aspnetcore:2.2.2'
 - name: 'gcr.io/kaniko-project/executor:v0.4.0'
   args: ['--destination=$_OUTPUT_IMAGE']
+
+

--- a/tools/updater/aspnet.go
+++ b/tools/updater/aspnet.go
@@ -1,0 +1,99 @@
+package updater
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	aspNetCorePath = "aspnetcore.yaml"
+	cloudBuildPath = "builder/cloudbuild.yaml"
+)
+
+// cloudBuildSteps represents the steps included in aspnetcore.yaml
+type cloudBuildSteps struct {
+	Steps []cloudBuildStep `yaml:"steps"`
+}
+
+// cloudBuildStep represents a single YAML step
+type cloudBuildStep struct {
+	Name string
+	Args []string
+}
+
+// ASPNetCoreVersion updates
+type ASPNetCoreVersion struct{}
+
+// Check that the value is in the version map
+func (*ASPNetCoreVersion) Check(c *StepConfig) error {
+	return checkCloudBuildVersionMap(aspNetCorePath, aspNetCoreBucket(c.Value), c)
+}
+
+func (*ASPNetCoreVersion) Apply(c *StepConfig) error {
+	return updateCloudBuildVersionMap(aspNetCorePath, aspNetCoreBucket(c.Value), c)
+}
+
+// aspNetCoreBucket returns the GCR bucket location for an aspnetcore version
+func aspNetCoreBucket(version string) string {
+	return fmt.Sprintf("gcr.io/google-appengine/aspnetcore:%s", version)
+}
+
+type CloudBuildVersion struct{}
+
+func (*CloudBuildVersion) Check(c *StepConfig) error {
+	return checkCloudBuildVersionMap(cloudBuildPath, fmt.Sprintf("%s=aspnetcore:%s", c.Value, c.Target), c)
+}
+func (*CloudBuildVersion) Apply(c *StepConfig) error {
+	return updateCloudBuildVersionMap(cloudBuildPath, fmt.Sprintf("%s=aspnetcore:%s", c.Value, c.Target), c)
+}
+
+func checkCloudBuildVersionMap(path string, newValue string, c *StepConfig) error {
+	f, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	ys := &cloudBuildSteps{}
+	err = yaml.Unmarshal(f, ys)
+	if err != nil {
+		return err
+	}
+	if len(ys.Steps) == 0 {
+		return fmt.Errorf("no steps found in %s", path)
+	}
+
+	seen := []string{}
+	for _, a := range ys.Steps[0].Args {
+		if !strings.Contains(a, "=") {
+			continue
+		}
+		parts := strings.Split(a, "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("unexpected data: %v", parts)
+		}
+		tag := parts[0]
+		value := parts[1]
+		seen = append(seen, tag)
+		if tag == c.Value {
+			if value != newValue {
+				return fmt.Errorf("%s has unexpected value: %s", tag, value)
+			}
+			c.Logger("Found: %s", a)
+			return nil
+		}
+	}
+	return fmt.Errorf("%s not in %s version map, found: %v", c.Value, path, seen)
+}
+
+func updateCloudBuildVersionMap(path, newValue string, c *StepConfig) error {
+	return SearchReplace(path, &MutateOptions{
+		Src:    regexp.MustCompile(fmt.Sprintf(`- '%s[\.\d]+=[a-z.*]:[\.\d]+'`, c.Target)),
+		Repl:   fmt.Sprintf("- '%s=%s'", c.Value, newValue),
+		Before: regexp.MustCompile(`^-`),
+		After:  regexp.MustCompile(`^\s+- '--version-map'`),
+		Logger: c.Logger,
+	})
+}

--- a/tools/updater/cmd/updater.go
+++ b/tools/updater/cmd/updater.go
@@ -1,0 +1,44 @@
+/*
+
+usage:
+
+go run update_versions.go 1.0=1.0.13 2.1=2.1.504
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tstromberg/aspnet-docker/tools/updater"
+)
+
+func updateVersion(tag string, version string) error {
+	steps := []updater.Step{
+		&updater.ASPNetCoreVersion{},
+		&updater.CloudBuildVersion{},
+		/*		GlobalJSONVersion,
+				IntegrationTestsVersion,
+				StructuralTestsVersion,
+				DockerFileVersion,
+				BuildRuntimesTagVersion, */
+	}
+	return updater.Run(steps, &updater.StepConfig{Target: tag, Value: version})
+}
+
+func main() {
+	for _, a := range os.Args[1:] {
+		if !strings.Contains(a, "=") {
+			panic(fmt.Sprintf("Argument has no equal sign: %s", a))
+		}
+		parts := strings.Split(a, "=")
+		fmt.Printf("parts: %v\n", parts)
+		err := updateVersion(parts[0], parts[1])
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+}

--- a/tools/updater/mutate.go
+++ b/tools/updater/mutate.go
@@ -1,0 +1,87 @@
+package updater
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+)
+
+type MutateOptions struct {
+	Src  *regexp.Regexp
+	Repl string
+
+	After  *regexp.Regexp
+	Before *regexp.Regexp
+
+	Logger Logger
+}
+
+func SearchReplace(path string, o *MutateOptions) error {
+	o.Logger("%s: replace %q with %q", path, o.Src, o.Repl)
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	newLines := [][]byte{}
+	scanner := bufio.NewScanner(f)
+	foundStart := false
+	foundEnd := false
+	changes := 0
+
+	if o.After == nil {
+		foundStart = true
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if o.After.Match(line) {
+			o.Logger("Found start: %s", line)
+			foundStart = true
+		}
+		if foundStart && o.Before != nil && o.Before.Match(line) {
+			o.Logger("Found end:   %s", line)
+			foundEnd = true
+		}
+
+		if foundStart && !foundEnd && o.Src.Match(line) {
+			newLine := o.Src.ReplaceAll(line, []byte(o.Repl))
+			newLines = append(newLines, newLine)
+			if !bytes.Equal(newLine, line) {
+				o.Logger("Old:   %s", line)
+				o.Logger("New:   %s", newLine)
+				changes++
+			}
+			continue
+		}
+		newLines = append(newLines, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if !foundStart {
+		return fmt.Errorf("start missing: %s", o.After)
+	}
+
+	if changes == 0 {
+		return fmt.Errorf("no changes could be made")
+	}
+	o.Logger("%d lines changed", changes)
+
+	// Trailing newline
+	newLines = append(newLines, []byte("\n"))
+	// NOTE: does not synchronously write.
+	out := bytes.Join(newLines, []byte("\n"))
+	if err := ioutil.WriteFile(path, out, os.FileMode(0600)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/updater/runner.go
+++ b/tools/updater/runner.go
@@ -1,0 +1,90 @@
+package updater
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Steps are a standardized interface to a reliably make changes to a system
+type Step interface {
+	Check(*StepConfig) error
+	Apply(*StepConfig) error
+}
+
+type Logger func(format string, args ...interface{})
+
+// StepConfig are options to steps: intended to be as generic as possible.
+type StepConfig struct {
+	// Logger is a callback for logging.
+	Logger Logger
+	// Target is a string representation of an object to update (required)
+	Target string
+	// Optional value to update the target with (optional)
+	Value string
+}
+
+// defaultLogger is a default logging implementation.
+func defaultLogger(format string, args ...interface{}) {
+	fmt.Printf("  > "+format+"\n", args...)
+}
+
+// Run executes a series of steps, with console output.
+func Run(steps []Step, c *StepConfig) error {
+	var failures []error
+	if c.Logger == nil {
+		c.Logger = defaultLogger
+	}
+
+	for i, s := range steps {
+		if i > 0 {
+			fmt.Println("")
+		}
+		name := stepName(s)
+		fmt.Printf("[%d/%d] %s\n", i+1, len(steps), name)
+		err := s.Check(c)
+		if err == nil {
+			fmt.Println("  ✔️ pre-check:  passed")
+			continue
+		} else {
+			fmt.Printf("  ✖️️ pre-check:  %s\n", err)
+		}
+
+		if len(failures) > 0 {
+			fmt.Println("  ⏳apply:      skipping (previous step failed)")
+			continue
+		}
+
+		err = s.Apply(c)
+		if err != nil {
+			fmt.Printf("  ✖️ apply:      %v\n", err)
+			failures = append(failures, fmt.Errorf("%s apply: %v", name, err))
+			continue
+		} else {
+			fmt.Println("  ✔️ apply:      successful")
+		}
+
+		err = s.Check(c)
+		if err != nil {
+			fmt.Printf("  ✖ post-check: %v\n", err)
+			failures = append(failures, fmt.Errorf("%s post-check: %v", name, err))
+			continue
+		}
+		fmt.Println("  ✔️ post-check: passed")
+	}
+
+	fmt.Println("")
+	if len(failures) == 1 {
+		return fmt.Errorf("error: %v", failures[0])
+	}
+	if len(failures) > 1 {
+		return fmt.Errorf("errors: %v", failures)
+	}
+	return nil
+}
+
+// stepName returns the name of a function, using reflection.
+func stepName(i interface{}) string {
+	return strings.Replace(strings.Replace(reflect.TypeOf(i).String(), "*", "", 1), "updater.", "", 1)
+	//	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}


### PR DESCRIPTION
It's a raw and partial implementation, but I wanted to be up front with what I was working on. The intent is to  replace some gnarly Perl scripts I had previously used, but in the future, would go further than that: 

Usage:
`go run tools/updater/cmd/updater.go 2.1=2.111`

Example output:

```
[1/2] ASPNetCoreVersion
  > Found: 2.111=gcr.io/google-appengine/aspnetcore:2.111
  ✔️ pre-check:  passed

[2/2] CloudBuildVersion
  ✖️️ pre-check:  yaml: unmarshal errors:
  line 96: cannot unmarshal !!str `functio...` into []string
  line 99: cannot unmarshal !!str `functio...` into []string
  line 102: cannot unmarshal !!str `functio...` into []string
  line 105: cannot unmarshal !!str `functio...` into []string
  line 108: cannot unmarshal !!str `functio...` into []string
  line 111: cannot unmarshal !!str `functio...` into []string
  ✖️ apply:      no changes could be made

error: CloudBuildVersion apply: no changes could be made

```

You may notice that this includes a general execution framework for reliably updating runtimes. If this prototype is successful, we could adjust it for other runtimes as well. 